### PR TITLE
Handling errors in authenticate

### DIFF
--- a/reddit_subreddit_block.py
+++ b/reddit_subreddit_block.py
@@ -66,9 +66,14 @@ class SubredditFeed(RESTPolling):
         """
         Overridden from RESTPolling block.
 
-        Retrieves the OAuth token and saves it to the instance
+        Retrieves the OAuth token and saves it to the instance. If there is
+        an error during authentication, the token will be set to None.
         """
-        self.token = self.get_token()
+        try:
+            self.token = self.get_token()
+        except:
+            self._logger.exception("Error authenticating, invalidating token")
+            self.token = None
 
     def init_post_id(self, query):
         """

--- a/tests/test_reddit_subreddit_block.py
+++ b/tests/test_reddit_subreddit_block.py
@@ -21,6 +21,14 @@ class TestSubredditFeed(NIOBlockTestCase):
                          {'User-Agent': 'nio',
                           'Authorization': 'bearer TEST TOKEN'})
 
+    def test_authenticate_error(self):
+        """ Test that headers are properly set after _authenticate. """
+        blk = SubredditFeed()
+        # Simulate a failure to parse JSON in the token retrieval
+        blk.get_token = MagicMock(side_effect=ValueError)
+        blk._authenticate()
+        self.assertIsNone(blk.token)
+
     def test_prepare_url(self):
         """ Test url has a before query param and appends proper subreddit. """
         blk = SubredditFeed()


### PR DESCRIPTION
Before this fix, here is the sequence of events that was causing a block failure:
1. Polling response fails with a bad status (e.g. 502)
2. Block attempts to retry, which kicks off an `_authenticate` call.
3. Authenticate makes a request to get the token, which returns invalid JSON because the API is down
4. Authenticate raises exception trying to parse that JSON
5. Exception propagates up and causes block to think there was a problem processing the original response.
6. As a result, epilogue never gets called and no subsequent poll takes place, in essence putting the block into an idle state.
